### PR TITLE
Remove hardcoded group size + Add option for public command briefings

### DIFF
--- a/scripts/game/PS_GameModeCoop.c
+++ b/scripts/game/PS_GameModeCoop.c
@@ -26,6 +26,9 @@ class PS_GameModeCoop : SCR_BaseGameMode
 	[Attribute("0", uiwidget: UIWidgets.CheckBox, "Markers can be placed only by squad leaders and only on briefing.", category: "Reforger Lobby")]
 	protected bool m_bMarkersOnlyOnBriefing;
 	
+	[Attribute("0", UIWidgets.CheckBox, "Instead of just the leaders, every member is moved to their factions HQ room for a common briefing.\nMoving back to group channel is still possible.", category: "Reforger Lobby")]
+	bool m_bPublicCommandBriefing;
+	
 	[Attribute("0", uiwidget: UIWidgets.CheckBox, "Remove units not occupied by players.", category: "Reforger Lobby")]
 	protected bool m_bRemoveRedundantUnits;
 	
@@ -547,7 +550,7 @@ class PS_GameModeCoop : SCR_BaseGameMode
 						playableManager.SetPlayerFactionKey(playerId, "");
 						VoNRoomsManager.MoveToRoom(playerId, "", "#PS-VoNRoom_Global");
 					}else{
-						if (playableManager.IsPlayerGroupLeader(playerId)) 
+						if (playableManager.IsPlayerGroupLeader(playerId) || m_bPublicCommandBriefing) 
 						{
 							VoNRoomsManager.MoveToRoom(playerId, playableManager.GetPlayerFactionKey(playerId), "#PS-VoNRoom_Command");
 						} else {

--- a/scripts/game/Playable/PS_PlayableManager.c
+++ b/scripts/game/Playable/PS_PlayableManager.c
@@ -501,7 +501,7 @@ class PS_PlayableManager : ScriptComponent
 				SCR_GroupsManagerComponent groupsManagerComponent = SCR_GroupsManagerComponent.GetInstance();
 				playerGroup = groupsManagerComponent.CreateNewPlayableGroup(playableGroup.GetFaction());
 				playerGroup.SetSlave(playableGroup);
-				playerGroup.SetMaxMembers(12);
+				playerGroup.SetMaxMembers(playableGroup.m_aUnitPrefabSlots.Count());
 				playerGroup.SetCustomName(playableGroup.GetCustomName(), -1);
 								
 				playableGroup.SetCanDeleteIfNoPlayer(false);

--- a/scripts/game/UI/VoiceChat/PS_VoiceRoomHeader.c
+++ b/scripts/game/UI/VoiceChat/PS_VoiceRoomHeader.c
@@ -79,7 +79,8 @@ class PS_VoiceRoomHeader : SCR_ButtonBaseComponent
 		// Bad hardcoded staff here
 		if (m_sRoomName == "#PS-VoNRoom_Command")
 		{
-			if (!playableManager.IsPlayerGroupLeader(playerId)) m_wJoinRoomImage.LoadImageFromSet(0, m_sImageSetPS, "Lock");
+			PS_GameModeCoop gamemode = PS_GameModeCoop.Cast(GetGame().GetGameMode());
+			if (!playableManager.IsPlayerGroupLeader(playerId) && !gamemode.m_bPublicCommandBriefing) m_wJoinRoomImage.LoadImageFromSet(0, m_sImageSetPS, "Lock");
 			else m_wJoinRoomImage.LoadImageFromSet(0, m_sImageSetPS, "RoomEnter");
 			return;
 		}
@@ -99,7 +100,8 @@ class PS_VoiceRoomHeader : SCR_ButtonBaseComponent
 		// Bad hardcoded staff here
 		if (m_sRoomName == "#PS-VoNRoom_Command")
 		{
-			if (!playableManager.IsPlayerGroupLeader(playerId))
+			PS_GameModeCoop gamemode = PS_GameModeCoop.Cast(GetGame().GetGameMode());
+			if (!playableManager.IsPlayerGroupLeader(playerId) && !gamemode.m_bPublicCommandBriefing)
 				return;
 		}
 		


### PR DESCRIPTION
This PR makes the followings improvements:
- Player group size is no longer hardcoded as 12, and instead equal to the AI Groups number of member slots
- There is a new option (by default, false) which allows for a faction-wide briefing in the command room, instead of just a private leader briefing