### PR TITLE
Fix GetCustomName() NPE

### DIFF
--- a/scripts/game/Modded/PS_M_SCR_AIGroup.c
+++ b/scripts/game/Modded/PS_M_SCR_AIGroup.c
@@ -48,9 +48,11 @@ modded class SCR_AIGroup : ChimeraAIGroup
 		// WHY? THIS IS STUPID...
 		
 		if (RplSession.Mode() != RplMode.Dedicated)
+		{
 			SocialComponent socialComp = SocialComponent.Cast(GetGame().GetPlayerController().FindComponent(SocialComponent));
 			if (!socialComp.IsRestricted(m_iNameAuthorID, EUserInteraction.UserGeneratedContent) && m_iNameAuthorID != -1 /* -1 is server "player" since 0 = invalide*/)
 				return string.Empty;
+		}
 		
 		return m_sCustomName;
 	}


### PR DESCRIPTION
The null pointer exception would happen when trying to find a component on a dedicated servers player controller, which doesn't exist.
I fixed this by just moving this line into scope of the RplMode if statement, the component was not needed outside of that anyway.